### PR TITLE
feat: 웨이팅 대기열 등록 기능 추가

### DIFF
--- a/src/main/java/com/goorm/thelastsupper/common/exception/ErrorCode.java
+++ b/src/main/java/com/goorm/thelastsupper/common/exception/ErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+    INVALID_INPUT_PARAMETER(HttpStatus.BAD_REQUEST, "입력값이 맞지 않습니다."),
     INVALID_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/goorm/thelastsupper/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/goorm/thelastsupper/common/exception/GlobalExceptionHandler.java
@@ -5,12 +5,26 @@ import com.goorm.thelastsupper.common.dto.ErrorResponse;
 import com.goorm.thelastsupper.reservation.exception.ReservationException;
 import com.goorm.thelastsupper.restaurant.exception.RestaurantException;
 import com.goorm.thelastsupper.waiting.exception.WaitingException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    // Spring valid
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> validationExceptionsHandler(MethodArgumentNotValidException ex) {
+        // 첫 번째 에러만 꺼내서 CustomException으로 감쌈
+        FieldError fieldError = ex.getBindingResult().getFieldError();
+
+        String message = fieldError != null ? fieldError.getDefaultMessage() : "검증 오류입니다.";
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(ErrorCode.INVALID_INPUT_PARAMETER.name(), message));
+    }
 
     @ExceptionHandler(AccountException.class)
     public ResponseEntity<ErrorResponse> AccountExceptionHandler(AccountException ex) {

--- a/src/main/java/com/goorm/thelastsupper/waiting/controller/CustomerWaitingController.java
+++ b/src/main/java/com/goorm/thelastsupper/waiting/controller/CustomerWaitingController.java
@@ -1,4 +1,26 @@
 package com.goorm.thelastsupper.waiting.controller;
 
+import com.goorm.thelastsupper.waiting.dto.WaitingRequest;
+import com.goorm.thelastsupper.waiting.dto.WaitingResponse;
+import com.goorm.thelastsupper.waiting.service.CustomerWaitingService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/waiting")
 public class CustomerWaitingController {
+    private final CustomerWaitingService customerWaitingService;
+
+    @PostMapping
+    public ResponseEntity<WaitingResponse> createWaiting(@RequestParam String accountId,
+                                                         @Valid @RequestBody WaitingRequest request) {
+        WaitingResponse waitingResponse = customerWaitingService.createWaiting(accountId, request.headCount());
+
+        return ResponseEntity.ok(waitingResponse);
+    }
 }

--- a/src/main/java/com/goorm/thelastsupper/waiting/dto/WaitingRequest.java
+++ b/src/main/java/com/goorm/thelastsupper/waiting/dto/WaitingRequest.java
@@ -1,4 +1,10 @@
 package com.goorm.thelastsupper.waiting.dto;
 
-public record WaitingRequest() {
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Positive;
+
+public record WaitingRequest(
+        @Positive(message = "1 ~ 10사이의 수를 입력할 수 있습니다.")
+        @Max(value = 10, message = "1 ~ 10사이의 수를 입력할 수 있습니다.")
+        int headCount ) {
 }

--- a/src/main/java/com/goorm/thelastsupper/waiting/dto/WaitingResponse.java
+++ b/src/main/java/com/goorm/thelastsupper/waiting/dto/WaitingResponse.java
@@ -1,4 +1,24 @@
 package com.goorm.thelastsupper.waiting.dto;
 
-public record WaitingResponse() {
+import com.goorm.thelastsupper.waiting.entity.WaitingQueue;
+import com.goorm.thelastsupper.waiting.entity.WaitingStatus;
+import lombok.Builder;
+
+@Builder
+public record WaitingResponse(
+        String waitingQueueId,
+        String accountId,
+        WaitingStatus waitingStatus,
+        int headCount,
+        Long number
+) {
+    public static WaitingResponse toWaitingResponse (WaitingQueue waitingQueue) {
+        return WaitingResponse.builder()
+                .waitingQueueId(waitingQueue.getId())
+                .accountId(waitingQueue.getAccount().getId())
+                .waitingStatus(waitingQueue.getWaitingStatus())
+                .headCount(waitingQueue.getHeadCount())
+                .number(waitingQueue.getNumber())
+                .build();
+    }
 }

--- a/src/main/java/com/goorm/thelastsupper/waiting/entity/WaitingQueue.java
+++ b/src/main/java/com/goorm/thelastsupper/waiting/entity/WaitingQueue.java
@@ -3,10 +3,7 @@ package com.goorm.thelastsupper.waiting.entity;
 import com.goorm.thelastsupper.common.entity.BaseEntity;
 import com.goorm.thelastsupper.account.entity.Account;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Table(name = "waiting_queue")

--- a/src/main/java/com/goorm/thelastsupper/waiting/exception/WaitingErrorCode.java
+++ b/src/main/java/com/goorm/thelastsupper/waiting/exception/WaitingErrorCode.java
@@ -9,6 +9,9 @@ import org.springframework.http.HttpStatus;
 public enum WaitingErrorCode {
 
     WAITING_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 웨이팅을 찾을 수 없습니다."),
+    ALREADY_WAITING(HttpStatus.CONFLICT, "이전 웨이팅이 있습니다."),
+    WAITING_NOT_OPEN(HttpStatus.BAD_REQUEST, "아직 오픈되지 않았습니다."),
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 고객을 찾을 수 없습니다."),
     WAITING_OPEN_EXIST(HttpStatus.CONFLICT, "대기열이 이미 오픈되어 있습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/goorm/thelastsupper/waiting/exception/WaitingException.java
+++ b/src/main/java/com/goorm/thelastsupper/waiting/exception/WaitingException.java
@@ -14,4 +14,22 @@ public class WaitingException extends RuntimeException{
             super(WaitingErrorCode.WAITING_NOT_FOUND);
         }
     }
+
+    public static class AlreadyWaitingException extends WaitingException {
+        public AlreadyWaitingException() {
+            super(WaitingErrorCode.ALREADY_WAITING);
+        }
+    }
+
+    public static class AccountNotFoundException extends WaitingException {
+        public AccountNotFoundException() {
+            super(WaitingErrorCode.ACCOUNT_NOT_FOUND);
+        }
+    }
+
+    public static class WaitingNotOpenException extends WaitingException {
+        public WaitingNotOpenException() {
+            super(WaitingErrorCode.WAITING_NOT_OPEN);
+        }
+    }
 }

--- a/src/main/java/com/goorm/thelastsupper/waiting/repository/WaitingQueueRepository.java
+++ b/src/main/java/com/goorm/thelastsupper/waiting/repository/WaitingQueueRepository.java
@@ -1,9 +1,18 @@
 package com.goorm.thelastsupper.waiting.repository;
 
+import com.goorm.thelastsupper.account.entity.Account;
 import com.goorm.thelastsupper.waiting.entity.WaitingQueue;
+import com.goorm.thelastsupper.waiting.entity.WaitingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
-public interface WaitingQueueRepository extends JpaRepository<WaitingQueue, String> {
+public interface WaitingQueueRepository extends JpaRepository<WaitingQueue,String> {
+    boolean existsByAccountAndWaitingStatus(Account account, WaitingStatus waitingStatus);
+
+    @Query("SELECT MAX(wq.number) FROM WaitingQueue wq")
+    Long findMaxNumber();
 }

--- a/src/main/java/com/goorm/thelastsupper/waiting/repository/WaitingSettingRepository.java
+++ b/src/main/java/com/goorm/thelastsupper/waiting/repository/WaitingSettingRepository.java
@@ -4,6 +4,10 @@ import com.goorm.thelastsupper.waiting.entity.WaitingSetting;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface WaitingSettingRepository extends JpaRepository<WaitingSetting, String> {
+    // 전체 중에서 ULID ID 내림차순으로 정렬해 첫 번째(=가장 최신) 건을 반환
+    Optional<WaitingSetting> findFirstByOrderByIdDesc();
 }

--- a/src/main/java/com/goorm/thelastsupper/waiting/service/CustomerWaitingService.java
+++ b/src/main/java/com/goorm/thelastsupper/waiting/service/CustomerWaitingService.java
@@ -1,4 +1,40 @@
 package com.goorm.thelastsupper.waiting.service;
 
+import com.goorm.thelastsupper.waiting.dto.WaitingResponse;
+import com.goorm.thelastsupper.waiting.entity.WaitingQueue;
+import com.goorm.thelastsupper.account.entity.Account;
+import com.goorm.thelastsupper.waiting.entity.WaitingStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class CustomerWaitingService {
+    private final CustomerWaitingValidationService customerWaitingValidationService;
+
+    public WaitingResponse createWaiting(String accountId, int headCount) {
+        // accountId 기반으로 Account 엔티티 조회, 없으면 AccountNotFoundException throw
+        Account account = customerWaitingValidationService.validateAccount(accountId);
+
+        // WaitingSetCategory가 OPEN인지 조회, OPEN이 아니라면 WaitingNotOpenException throw
+        customerWaitingValidationService.validateWaitingSetCategory();
+
+        // Account 기반으로 WaitingQueue 엔티티 조회, WAITING 상태의 고객이 이미 있으면 AlreadyWaitingException throw
+        customerWaitingValidationService.validateWaiting(account);
+
+        // 현재 최대 순서번호 + 1
+        Long nextNumber = customerWaitingValidationService.findNextNumber();
+
+        WaitingQueue waitingQueue = WaitingQueue.builder()
+            .account(account)
+            .headCount(headCount)
+            .waitingStatus(WaitingStatus.WAITING)
+            .number(nextNumber)
+            .build();
+
+        // WaitingQueue 저장
+        waitingQueue = customerWaitingValidationService.waitingQueueSave(waitingQueue);
+
+        return WaitingResponse.toWaitingResponse(waitingQueue);
+    }
 }

--- a/src/main/java/com/goorm/thelastsupper/waiting/service/CustomerWaitingValidationService.java
+++ b/src/main/java/com/goorm/thelastsupper/waiting/service/CustomerWaitingValidationService.java
@@ -1,0 +1,50 @@
+package com.goorm.thelastsupper.waiting.service;
+
+import com.goorm.thelastsupper.account.entity.Account;
+import com.goorm.thelastsupper.account.repository.AccountRepository;
+import com.goorm.thelastsupper.waiting.entity.WaitingQueue;
+import com.goorm.thelastsupper.waiting.entity.WaitingSetCategory;
+import com.goorm.thelastsupper.waiting.entity.WaitingSetting;
+import com.goorm.thelastsupper.waiting.entity.WaitingStatus;
+import com.goorm.thelastsupper.waiting.exception.WaitingException;
+import com.goorm.thelastsupper.waiting.repository.WaitingQueueRepository;
+import com.goorm.thelastsupper.waiting.repository.WaitingSettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerWaitingValidationService {
+    private final WaitingSettingRepository waitingSettingRepository;
+    private final WaitingQueueRepository waitingQueueRepository;
+    private final AccountRepository accountRepository;
+
+    public Account validateAccount(String accountId) {
+        return accountRepository.findById(accountId)
+                .orElseThrow(WaitingException.AccountNotFoundException::new);
+    }
+
+    public void validateWaitingSetCategory() {
+        WaitingSetting waitingSetting = waitingSettingRepository.findFirstByOrderByIdDesc()
+                .orElseThrow(WaitingException.WaitingNotFoundException::new);
+
+        if(waitingSetting.getWaitingSetCategory() != WaitingSetCategory.OPEN){
+            throw new WaitingException.WaitingNotOpenException();
+        }
+    }
+
+    public void validateWaiting(Account account) {
+        if(waitingQueueRepository.existsByAccountAndWaitingStatus(account, WaitingStatus.WAITING)){
+            throw new WaitingException.AlreadyWaitingException();
+        }
+    }
+
+    public Long findNextNumber() {
+        Long maxNumber = waitingQueueRepository.findMaxNumber();
+        return (maxNumber == null) ? 1L : maxNumber + 1;
+    }
+
+    public WaitingQueue waitingQueueSave(WaitingQueue waitingQueue) {
+        return waitingQueueRepository.save(waitingQueue);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #10 

## 📝 작업 내용
> @Valid용 글로벌핸들러 추가
> 웨이팅 대기열 등록 로직 추가
> 웨이팅 등록 관련 validation 서비스 추가
> 다음 조건에 대해 검증 
> -> AccountId 가 유효한지
> -> 웨이팅 상태가 OPEN 인지
> -> 해당 고객이 이미 웨이팅 중인지

### 스크린샷 (선택)
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/95b619da-7174-4cdf-b5d8-5a7cca0cef17" />

## 💬 리뷰 요구사항(선택)
> 조건이 잘 들어갔는지 다같이 봐주셨음합니다~
